### PR TITLE
Add kafka_records_recevied metric

### DIFF
--- a/gcn_monitor/kafka.py
+++ b/gcn_monitor/kafka.py
@@ -42,3 +42,5 @@ def run():
                 log.error("topic %s: got error %s", topic, error)
             else:
                 log.info("topic %s: got message", topic)
+                partition = message.partition()
+                metrics.received.labels(topic, partition).inc()

--- a/gcn_monitor/metrics.py
+++ b/gcn_monitor/metrics.py
@@ -30,3 +30,11 @@ broker_state = prometheus_client.Enum(
     subsystem="broker",
     labelnames=["name"],
 )
+
+received = prometheus_client.Counter(
+    "received",
+    "Kafka records received",
+    namespace="kafka",
+    subsystem="records",
+    labelnames=["topic", "partition"],
+)


### PR DESCRIPTION
Now that we have a heartbeat topic, we can add metrics to count received messages, and we can add an alarm if the heartbeats are interrupted.